### PR TITLE
Fix iCloud container ID casing - must start with iCloud. not icloud.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -118,7 +118,7 @@ SimplyHealth/
 
 ## Cloud and Sharing Features
 
-- CloudKit container identifier: `icloud.com.purus.health`
+- CloudKit container identifier: `iCloud.com.purus.health`
 - Sharing is per-record, not app-wide
 - Use `CloudSyncService` for cloud operations
 - Track record location status: `.local`, `.iCloud`, or `.shared`

--- a/SimplyHealth.entitlements
+++ b/SimplyHealth.entitlements
@@ -4,7 +4,7 @@
 <dict>
   <key>com.apple.developer.icloud-container-identifiers</key>
   <array>
-    <string>icloud.com.purus.health</string>
+    <string>iCloud.com.purus.health</string>
   </array>
   <key>com.apple.developer.icloud-services</key>
   <array>

--- a/SimplyHealth/AppConfig.swift
+++ b/SimplyHealth/AppConfig.swift
@@ -12,7 +12,7 @@ enum AppConfig {
     /// CloudKit configuration constants
     enum CloudKit {
         /// CloudKit container identifier
-        static let containerID = "icloud.com.purus.health"
+        static let containerID = "iCloud.com.purus.health"
 
         /// Custom zone name for sharing
         static let shareZoneName = "PurusHealthShareZone"

--- a/SimplyHealth/SimplyHealth.entitlements
+++ b/SimplyHealth/SimplyHealth.entitlements
@@ -4,7 +4,7 @@
 <dict>
   <key>com.apple.developer.icloud-container-identifiers</key>
   <array>
-    <string>icloud.com.purus.health</string>
+    <string>iCloud.com.purus.health</string>
   </array>
   <key>com.apple.developer.icloud-services</key>
   <array>


### PR DESCRIPTION
Apple requires iCloud container identifiers to start with uppercase 'iCloud.'

## Summary by Sourcery

Correct iCloud CloudKit container identifier casing across the app and project configuration.

Bug Fixes:
- Fix CloudKit container identifier to use the required `iCloud.` prefix casing in app configuration.

Documentation:
- Update Copilot instructions to reference the correctly cased iCloud container identifier.

Chores:
- Adjust project entitlements file reference for SimplyHealth without changing its contents.