### PR TITLE
Fix iCloud sharing display and warning fixes (without file renames)

### DIFF
--- a/SimplyHealth/Models/MedicalRecord.swift
+++ b/SimplyHealth/Models/MedicalRecord.swift
@@ -179,11 +179,15 @@ final class MedicalRecord {
 
     /// Centralized rule for what the UI should show.
     /// Priority: Shared > iCloud > Local.
+    /// Note: Shared records should show as shared even if isCloudEnabled is false,
+    /// because recipients of a share may not have cloud sync enabled for their own records.
     var locationStatus: RecordLocationStatus {
+        // Check sharing status first - a shared record should always show as shared
+        // regardless of the local isCloudEnabled flag
+        if isSharingEnabled || cloudShareRecordName != nil {
+            return .shared
+        }
         if isCloudEnabled {
-            if isSharingEnabled || cloudShareRecordName != nil {
-                return .shared
-            }
             return .iCloud
         }
         return .local

--- a/SimplyHealth/Services/CloudKitMedicalRecordFetcher.swift
+++ b/SimplyHealth/Services/CloudKitMedicalRecordFetcher.swift
@@ -24,8 +24,9 @@ class CloudKitMedicalRecordFetcher: ObservableObject {
     // Persist the server change token so we can fetch incremental changes.
     private let changeTokenDefaultsKey = "CloudKitMedicalRecordFetcher.shareZoneChangeToken"
 
-    init(containerIdentifier: String = "iCloud.com.furfarch.MyHealthData", modelContext: ModelContext? = nil) {
-        self.container = CKContainer(identifier: containerIdentifier)
+    init(containerIdentifier: String? = nil, modelContext: ModelContext? = nil) {
+        let resolvedIdentifier = containerIdentifier ?? AppConfig.CloudKit.containerID
+        self.container = CKContainer(identifier: resolvedIdentifier)
         self.database = container.privateCloudDatabase
         self.modelContext = modelContext
     }

--- a/SimplyHealth/Services/CloudKitSharedMedicalRecordFetcher.swift
+++ b/SimplyHealth/Services/CloudKitSharedMedicalRecordFetcher.swift
@@ -7,13 +7,19 @@ import SwiftData
 final class CloudKitSharedMedicalRecordFetcher {
     private let container: CKContainer
     private let database: CKDatabase
-    private let recordType = AppConfig.CloudKit.recordType
+    private let recordType: String
     private var modelContext: ModelContext?
 
-    init(containerIdentifier: String = AppConfig.CloudKit.containerID, modelContext: ModelContext? = nil) {
+    init(containerIdentifier: String, modelContext: ModelContext? = nil) {
         self.container = CKContainer(identifier: containerIdentifier)
         self.database = container.sharedCloudDatabase
         self.modelContext = modelContext
+        self.recordType = AppConfig.CloudKit.recordType
+    }
+
+    @MainActor
+    convenience init(modelContext: ModelContext? = nil) {
+        self.init(containerIdentifier: AppConfig.CloudKit.containerID, modelContext: modelContext)
     }
 
     func setModelContext(_ context: ModelContext) {

--- a/SimplyHealth/Services/CloudKitSharedZoneMedicalRecordFetcher.swift
+++ b/SimplyHealth/Services/CloudKitSharedZoneMedicalRecordFetcher.swift
@@ -16,10 +16,14 @@ final class CloudKitSharedZoneMedicalRecordFetcher {
     // Keep in sync with the owner's record type.
     private let recordType = AppConfig.CloudKit.recordType
 
-    init(containerIdentifier: String = AppConfig.CloudKit.containerID, modelContext: ModelContext? = nil) {
+    init(containerIdentifier: String, modelContext: ModelContext? = nil) {
         self.container = CKContainer(identifier: containerIdentifier)
         self.database = container.sharedCloudDatabase
         self.modelContext = modelContext
+    }
+
+    convenience init(modelContext: ModelContext? = nil) {
+        self.init(containerIdentifier: AppConfig.CloudKit.containerID, modelContext: modelContext)
     }
 
     func setModelContext(_ context: ModelContext) {


### PR DESCRIPTION
- Fix locationStatus to show shared records regardless of isCloudEnabled
- Post didAcceptShare notification after import so UI refreshes
- Fix hardcoded container IDs in fetcher initializers

https://claude.ai/code/session_012wk2Q1YTJ9yaLbpHjGkrwz

## Summary by Sourcery

Improve handling and display of iCloud-shared medical records, including correct status reporting and UI refresh after share acceptance.

Bug Fixes:
- Ensure shared medical records are always reported as shared in the UI, even when local iCloud sync is disabled.
- Trigger a notification after importing shared records so views can refresh and display newly accepted shares.
- Use configurable CloudKit container identifiers instead of hardcoded values in shared record fetchers and the main medical record fetcher.

Enhancements:
- Return imported record display names from the shared records importer for downstream use in notifications.
- Introduce convenience initializers for CloudKit shared record fetchers that default to the app’s CloudKit container configuration.