### PR TITLE
Fix share acceptance feedback and prevent unwanted CloudKit fetches

### DIFF
--- a/PurusHealth/ContentView.swift
+++ b/PurusHealth/ContentView.swift
@@ -16,6 +16,10 @@ struct ContentView: View {
     @State private var showShareAcceptedAlert: Bool = false
     @State private var importedName: String = ""
 
+    // Show alert when share acceptance fails
+    @State private var showShareErrorAlert: Bool = false
+    @State private var shareErrorMessage: String = ""
+
     var body: some View {
         RecordListView()
             .onOpenURL { url in
@@ -84,6 +88,20 @@ struct ContentView: View {
                 Button("OK", role: .cancel) {}
             } message: {
                 Text("\(importedName) imported")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: NotificationNames.shareAcceptanceFailed)) { notif in
+                // Show error alert when share acceptance fails
+                if let userInfo = notif.userInfo, let errorMsg = userInfo["error"] as? String {
+                    shareErrorMessage = errorMsg
+                } else {
+                    shareErrorMessage = "An unknown error occurred while accepting the share."
+                }
+                showShareErrorAlert = true
+            }
+            .alert("Share Failed", isPresented: $showShareErrorAlert) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(shareErrorMessage)
             }
     }
     

--- a/PurusHealth/NotificationNames.swift
+++ b/PurusHealth/NotificationNames.swift
@@ -13,4 +13,7 @@ enum NotificationNames {
 
     /// Posted when a share URL is received (pending) — used to notify the UI to accept/import it
     static let pendingShareReceived = Notification.Name("PurusHealth.PendingShareReceived")
+
+    /// Posted when share acceptance fails - userInfo contains "error" key with Error description
+    static let shareAcceptanceFailed = Notification.Name("PurusHealth.ShareAcceptanceFailed")
 }

--- a/PurusHealth/Services/CloudKitShareAcceptanceService.swift
+++ b/PurusHealth/Services/CloudKitShareAcceptanceService.swift
@@ -51,6 +51,13 @@ final class CloudKitShareAcceptanceService {
         } catch {
             ShareDebugStore.shared.appendLog("CloudKitShareAcceptanceService: accept failed error=\(error)")
             ShareDebugStore.shared.lastError = error
+
+            // Post failure notification so the UI can show an error alert to the user
+            NotificationCenter.default.post(
+                name: NotificationNames.shareAcceptanceFailed,
+                object: nil,
+                userInfo: ["error": error.localizedDescription]
+            )
         }
     }
 


### PR DESCRIPTION
Share Acceptance:
- Add shareAcceptanceFailed notification to inform UI of errors
- Post error notification when share acceptance fails
- Add error alert in ContentView so users see what went wrong
- Previously failures were silent with no user feedback

CloudKit Fetch Guards:
- Add shouldFetchFromCloud() check before fetching from private database
- Add hasSharedRecordsLocally() check before fetching shared records
- Only sync if user has enabled cloud sync or has cloud-enabled records
- Prevents deleted local records from being re-imported after reinstall when cloud sync is not enabled

https://claude.ai/code/session_01CHDkneTYv75Ag7TpueSd6X

## Summary by Sourcery

Gate CloudKit fetches and syncing on user cloud settings and existing cloud-enabled/shared records, and surface share acceptance failures to the user via notifications and alerts.

New Features:
- Add UI alerting for CloudKit share acceptance failures driven by a new shareAcceptanceFailed notification.

Enhancements:
- Guard launch-time and foreground CloudKit fetches and sync operations behind checks for enabled cloud sync or existing cloud-enabled/shared records to avoid unnecessary or undesired imports.