### PR TITLE
Fix share URL not being processed when app opens from share link

### DIFF
--- a/PurusHealth/AppDelegate.swift
+++ b/PurusHealth/AppDelegate.swift
@@ -1,35 +1,70 @@
 #if canImport(UIKit)
 import Foundation
 import UIKit
+import CloudKit
 
 // Scene delegate to handle modern URL / userActivity delivery (iOS 13+ scenes)
 @objc
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        for context in URLContexts {
-            PendingShareStore.shared.pendingURL = context.url
-            // Post notification so ContentView can process the URL immediately
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(
-                    name: NotificationNames.pendingShareReceived,
-                    object: nil,
-                    userInfo: ["url": context.url]
-                )
-            }
+
+    // Called when app is COLD LAUNCHED (not running) - share data comes through options
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Check for share URL in URL contexts (cold launch via URL scheme)
+        for context in connectionOptions.urlContexts {
+            handleShareURL(context.url)
+        }
+
+        // Check for share in user activities (cold launch via universal link or CloudKit share)
+        for userActivity in connectionOptions.userActivities {
+            handleUserActivity(userActivity)
         }
     }
 
+    // Called when app is ALREADY RUNNING and receives a URL
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        for context in URLContexts {
+            handleShareURL(context.url)
+        }
+    }
+
+    // Called when app is ALREADY RUNNING and receives a user activity (universal link, CloudKit share)
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
-        if let url = userActivity.webpageURL {
-            PendingShareStore.shared.pendingURL = url
-            // Post notification so ContentView can process the URL immediately
+        handleUserActivity(userActivity)
+    }
+
+    private func handleShareURL(_ url: URL) {
+        ShareDebugStore.shared.appendLog("SceneDelegate: received URL: \(url.absoluteString)")
+        PendingShareStore.shared.pendingURL = url
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: NotificationNames.pendingShareReceived,
+                object: nil,
+                userInfo: ["url": url]
+            )
+        }
+    }
+
+    private func handleUserActivity(_ userActivity: NSUserActivity) {
+        ShareDebugStore.shared.appendLog("SceneDelegate: received userActivity type: \(userActivity.activityType)")
+
+        // Check for CloudKit share metadata first (most reliable for CloudKit shares)
+        if let metadata = userActivity.cloudKitShareMetadata {
+            ShareDebugStore.shared.appendLog("SceneDelegate: found cloudKitShareMetadata, container: \(metadata.containerIdentifier)")
+            PendingShareStore.shared.pendingMetadata = metadata
             DispatchQueue.main.async {
                 NotificationCenter.default.post(
                     name: NotificationNames.pendingShareReceived,
                     object: nil,
-                    userInfo: ["url": url]
+                    userInfo: ["metadata": metadata]
                 )
             }
+            return
+        }
+
+        // Fall back to webpage URL (universal links)
+        if let url = userActivity.webpageURL {
+            ShareDebugStore.shared.appendLog("SceneDelegate: found webpageURL: \(url.absoluteString)")
+            handleShareURL(url)
         }
     }
 }
@@ -43,11 +78,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return config
     }
 
-    // Fallback acceptance for older code paths (optional). Keep minimal.
+    // Fallback acceptance for older code paths (pre-scene apps). Keep minimal.
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        ShareDebugStore.shared.appendLog("AppDelegate: received userActivity type: \(userActivity.activityType)")
+
+        if let metadata = userActivity.cloudKitShareMetadata {
+            ShareDebugStore.shared.appendLog("AppDelegate: found cloudKitShareMetadata")
+            PendingShareStore.shared.pendingMetadata = metadata
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(
+                    name: NotificationNames.pendingShareReceived,
+                    object: nil,
+                    userInfo: ["metadata": metadata]
+                )
+            }
+            return true
+        }
+
         if let url = userActivity.webpageURL {
+            ShareDebugStore.shared.appendLog("AppDelegate: found webpageURL: \(url.absoluteString)")
             PendingShareStore.shared.pendingURL = url
-            // Post notification so ContentView can process the URL immediately
             DispatchQueue.main.async {
                 NotificationCenter.default.post(
                     name: NotificationNames.pendingShareReceived,
@@ -57,6 +107,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             return true
         }
+
         return false
     }
 }

--- a/PurusHealth/ContentView.swift
+++ b/PurusHealth/ContentView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import SwiftData
+import CloudKit
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
@@ -30,13 +31,13 @@ struct ContentView: View {
             }
             .task {
                 // Check for pending share URL on first appearance
-                await checkPendingShareURL()
+                await checkPendingShare()
             }
             .onChange(of: scenePhase) { oldPhase, newPhase in
                 // Check for pending share URL when app becomes active
                 if newPhase == .active {
                     Task { @MainActor in
-                        await checkPendingShareURL()
+                        await checkPendingShare()
                     }
                 }
             }
@@ -104,9 +105,21 @@ struct ContentView: View {
                 Text(shareErrorMessage)
             }
             .onReceive(NotificationCenter.default.publisher(for: NotificationNames.pendingShareReceived)) { notif in
-                // Process share URL immediately when received from SceneDelegate/AppDelegate
+                // Process share immediately when received from SceneDelegate/AppDelegate
                 // This handles the case where onOpenURL doesn't fire due to custom SceneDelegate
-                if let userInfo = notif.userInfo, let url = userInfo["url"] as? URL {
+                guard let userInfo = notif.userInfo else { return }
+
+                // Prefer metadata (more efficient - skips URL fetch)
+                if let metadata = userInfo["metadata"] as? CKShare.Metadata {
+                    ShareDebugStore.shared.appendLog("ContentView: received pendingShareReceived with metadata")
+                    Task { @MainActor in
+                        await CloudKitShareAcceptanceService.shared.acceptShare(from: metadata, modelContext: modelContext)
+                    }
+                    return
+                }
+
+                // Fall back to URL
+                if let url = userInfo["url"] as? URL {
                     ShareDebugStore.shared.appendLog("ContentView: received pendingShareReceived notification for URL: \(url)")
                     Task { @MainActor in
                         await CloudKitShareAcceptanceService.shared.acceptShare(from: url, modelContext: modelContext)
@@ -116,10 +129,17 @@ struct ContentView: View {
     }
     
     @MainActor
-    private func checkPendingShareURL() async {
+    private func checkPendingShare() async {
         #if canImport(UIKit)
-        // Check if there's a pending share URL from the AppDelegate
-        if let pendingURL = PendingShareStore.shared.consume() {
+        // Check for pending share metadata first (more efficient)
+        if let metadata = PendingShareStore.shared.consumeMetadata() {
+            ShareDebugStore.shared.appendLog("ContentView: processing pending share metadata from AppDelegate")
+            await CloudKitShareAcceptanceService.shared.acceptShare(from: metadata, modelContext: modelContext)
+            return
+        }
+
+        // Fall back to pending URL
+        if let pendingURL = PendingShareStore.shared.consumeURL() {
             ShareDebugStore.shared.appendLog("ContentView: processing pending share URL from AppDelegate")
             await CloudKitShareAcceptanceService.shared.acceptShare(from: pendingURL, modelContext: modelContext)
         }

--- a/PurusHealth/Support/PendingShareStore.swift
+++ b/PurusHealth/Support/PendingShareStore.swift
@@ -1,23 +1,43 @@
 import Foundation
+import CloudKit
 
-/// Small store to hold a pending share URL received before the SwiftUI scene is ready.
+/// Small store to hold a pending share URL or metadata received before the SwiftUI scene is ready.
 final class PendingShareStore {
     static let shared = PendingShareStore()
     private init() {}
 
     private let queue = DispatchQueue(label: "PendingShareStore")
     private var _pendingURL: URL?
+    private var _pendingMetadata: CKShare.Metadata?
 
     var pendingURL: URL? {
         get { queue.sync { _pendingURL } }
         set { queue.sync { _pendingURL = newValue } }
     }
 
-    func consume() -> URL? {
+    var pendingMetadata: CKShare.Metadata? {
+        get { queue.sync { _pendingMetadata } }
+        set { queue.sync { _pendingMetadata = newValue } }
+    }
+
+    func consumeURL() -> URL? {
         return queue.sync { () -> URL? in
             let u = _pendingURL
             _pendingURL = nil
             return u
         }
+    }
+
+    func consumeMetadata() -> CKShare.Metadata? {
+        return queue.sync { () -> CKShare.Metadata? in
+            let m = _pendingMetadata
+            _pendingMetadata = nil
+            return m
+        }
+    }
+
+    /// Legacy method - prefer consumeURL() or consumeMetadata()
+    func consume() -> URL? {
+        return consumeURL()
     }
 }


### PR DESCRIPTION
The SceneDelegate was capturing share URLs but not notifying ContentView, causing the share acceptance to never trigger. SwiftUI's onOpenURL modifier doesn't fire when a custom SceneDelegate intercepts URLs first.

Changes:
- SceneDelegate now posts pendingShareReceived notification when URL received
- AppDelegate also posts notification for fallback URL handling
- ContentView listens for pendingShareReceived and processes URL immediately
- This ensures share links work whether app is already running or cold-launched

https://claude.ai/code/session_01CHDkneTYv75Ag7TpueSd6X

## Summary by Sourcery

Bug Fixes:
- Fix share URLs not being processed when the app is opened or continued via a share link due to SceneDelegate intercepting URLs without notifying the SwiftUI view hierarchy.