### PR TITLE
Fix broken sync - remove incorrect empty database check

### DIFF
--- a/PurusHealth/PurusHealthApp.swift
+++ b/PurusHealth/PurusHealthApp.swift
@@ -99,25 +99,15 @@ struct PurusHealthApp: App {
         .modelContainer(modelContainer)
     }
     
-    /// Returns true if cloud sync should be performed (user has enabled cloud sync AND has records to sync).
+    /// Returns true if cloud sync should be performed.
     @MainActor
     private func shouldFetchFromCloud() async -> Bool {
-        let context = modelContainer.mainContext
-
-        // First check: are there ANY local records at all?
-        // On Mac Catalyst, UserDefaults persist after app deletion, so we can't trust
-        // cloudEnabled alone. If database is empty, this is a fresh install - don't fetch.
-        let allRecordsDescriptor = FetchDescriptor<MedicalRecord>()
-        let totalRecords = (try? context.fetchCount(allRecordsDescriptor)) ?? 0
-        if totalRecords == 0 {
-            return false
-        }
-
-        // Check global cloud setting
+        // Check global cloud setting first - if enabled, always sync
         let globalCloudEnabled = UserDefaults.standard.bool(forKey: "cloudEnabled")
         if globalCloudEnabled { return true }
 
         // Check if any local records are cloud-enabled
+        let context = modelContainer.mainContext
         let fetchDescriptor = FetchDescriptor<MedicalRecord>(predicate: #Predicate { $0.isCloudEnabled == true })
         let count = (try? context.fetchCount(fetchDescriptor)) ?? 0
         return count > 0


### PR DESCRIPTION
The previous check that returned false when totalRecords == 0 prevented fresh devices from syncing at all. Reverted to simpler logic:
- If globalCloudEnabled is true, always sync
- Otherwise, sync if any local records are cloud-enabled

https://claude.ai/code/session_01CHDkneTYv75Ag7TpueSd6X

## Summary by Sourcery

Bug Fixes:
- Remove the empty-database guard that blocked cloud sync on fresh installs and rely on global and per-record cloud-enabled flags instead.