### PR TITLE
Fix CloudKit delegate method signature and function call

### DIFF
--- a/PurusHealth/AppDelegate.swift
+++ b/PurusHealth/AppDelegate.swift
@@ -98,7 +98,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.rootViewController?.present(alert, animated: true)
     }
     
-    func scene(_ scene: UIScene, userDidAcceptCloudKitShareWith metadata: CKShare.Metadata) {
+    func windowScene(_ windowScene: UIWindowScene, userDidAcceptCloudKitShareWith metadata: CKShare.Metadata) {
         ShareDebugStore.shared.appendLog("SceneDelegate: userDidAcceptCloudKitShareWith (SceneDelegate) called")
         PendingShareStore.shared.pendingMetadata = metadata
         DispatchQueue.main.async {

--- a/PurusHealth/PurusHealthApp.swift
+++ b/PurusHealth/PurusHealthApp.swift
@@ -175,6 +175,6 @@ struct PurusHealthApp: App {
     
     @MainActor
     private func ensureSharedDBSubscription() async {
-        await ensureSharedDBSubscription(containerIdentifier: AppConfig.CloudKit.containerID)
+        await PurusHealth.ensureSharedDBSubscription(containerIdentifier: AppConfig.CloudKit.containerID)
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes two issues related to CloudKit integration and function scoping in the app delegate and main app structure.

## Key Changes
- **AppDelegate.swift**: Updated the CloudKit share acceptance delegate method signature from `scene(_:userDidAcceptCloudKitShareWith:)` to `windowScene(_:userDidAcceptCloudKitShareWith:)` to match the correct UIKit API for `UIWindowSceneDelegate`
- **PurusHealthApp.swift**: Fixed the function call to use the fully qualified name `PurusHealth.ensureSharedDBSubscription()` instead of the unqualified `ensureSharedDBSubscription()` to ensure proper scoping and avoid potential naming conflicts

## Implementation Details
The first change corrects the delegate method signature to properly handle CloudKit share invitations in window-based scenes. The second change ensures the subscription setup function is called with the correct namespace, improving code clarity and preventing ambiguity in function resolution.

https://claude.ai/code/session_01KnwriNaJoSinYJfdkMRHQ5

## Summary by Sourcery

Correct CloudKit integration in the scene delegate and fix the shared database subscription call scope.

Bug Fixes:
- Align the CloudKit share acceptance delegate method with the correct UIWindowSceneDelegate API so share invitations are handled properly.
- Call the shared database subscription helper via its fully qualified PurusHealth namespace to avoid scoping and resolution issues.